### PR TITLE
Added yarn

### DIFF
--- a/python/2.7/slim/Dockerfile
+++ b/python/2.7/slim/Dockerfile
@@ -6,6 +6,9 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl && \
     curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
     apt-get install --no-install-recommends -y \
         build-essential \
         gettext \
@@ -17,6 +20,7 @@ RUN apt-get update && \
         libpng12-dev \
         libssl-dev \
         nodejs \
+        yarn \
     && rm -rf /var/lib/apt/lists/*
 
 ## See https://github.com/krallin/tini/releases for latest release number

--- a/python/3.5/slim/Dockerfile
+++ b/python/3.5/slim/Dockerfile
@@ -6,6 +6,9 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl && \
     curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
     apt-get install --no-install-recommends -y \
         build-essential \
         gettext \
@@ -17,6 +20,7 @@ RUN apt-get update && \
         libpng12-dev \
         libssl-dev \
         nodejs \
+        yarn \
     && rm -rf /var/lib/apt/lists/*
 
 ## See https://github.com/krallin/tini/releases for latest release number

--- a/python/3.6/slim/Dockerfile
+++ b/python/3.6/slim/Dockerfile
@@ -6,6 +6,9 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update && \
     apt-get install --no-install-recommends -y curl && \
     curl -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
     apt-get install --no-install-recommends -y \
         build-essential \
         gettext \
@@ -17,6 +20,7 @@ RUN apt-get update && \
         libpng12-dev \
         libssl-dev \
         nodejs \
+        yarn \
     && rm -rf /var/lib/apt/lists/*
 
 ## See https://github.com/krallin/tini/releases for latest release number


### PR DESCRIPTION
Yarn can be used in place of npm to ensure images always have the exact same Node packages installed.